### PR TITLE
All the app store fixes

### DIFF
--- a/TempoWatch/ContainerView.swift
+++ b/TempoWatch/ContainerView.swift
@@ -7,7 +7,6 @@ class ContainerView: UIView{
     var scrollView: UIScrollView!
     var menuOpen: Bool = false
     var disableScrolling = false
-    
     var pauseImg: UIImage!
     var playImg: UIImage!
     var pauseImgV: UIImageView!
@@ -17,6 +16,8 @@ class ContainerView: UIView{
     
     var width: CGFloat!
     var height: CGFloat!
+    var homeViewSwipedOpen: (() -> ())?
+    var menuViewSwipedOpen: (() -> ())?
     
     override init(frame:CGRect){
         super.init(frame:frame)
@@ -64,19 +65,15 @@ class ContainerView: UIView{
         pauseImgV.alpha = 0
         pauseImgV.image = (pause) ? pauseImg : playImg
         UIView.animateWithDuration(0.1, delay: 0, options: .CurveEaseIn, animations: {
-            println("animation started")
             self.pauseImgV.alpha = 0.10
         }, completion: { finished in
-            println("animation continuing")
             UIView.animateWithDuration(0.2, delay: 0, options: .CurveEaseOut, animations: {
                 self.pauseImgV.frame = self.partialFrame
                 }, completion: { finished in
-                    println("animation finishing")
                     UIView.animateWithDuration(0.3, delay: 0, options: .CurveEaseOut, animations: {
                         self.pauseImgV.frame = self.bigFrame
                         self.pauseImgV.alpha = 0
                         }, completion: { finished in
-                            println("animation finished")
                     })
             })
         })
@@ -112,9 +109,11 @@ class ContainerView: UIView{
             if( swipeGesture.direction == UISwipeGestureRecognizerDirection.Right){
                 scrollView.setContentOffset(CGPointMake(0, 0), animated: true);
                 menuOpen = false;
+                homeViewSwipedOpen?()
             } else if( swipeGesture.direction == UISwipeGestureRecognizerDirection.Left ){
                 scrollView.setContentOffset(CGPointMake(width - 45, 0), animated: true);
                 menuOpen = true;
+                menuViewSwipedOpen?()
             }
         }
     }

--- a/TempoWatch/HomeView.swift
+++ b/TempoWatch/HomeView.swift
@@ -8,6 +8,7 @@ public class HomeView: UIView {
     var countDownLabel: UILabel!
     var width: CGFloat!
     var height: CGFloat!
+    var disableButtons = false
     var timerObj: TimerModel!{
         willSet(x){
             countDownLabel.text = String(x.getStartSeconds());
@@ -54,11 +55,22 @@ public class HomeView: UIView {
         countDownLabel.alpha = 0
         if((timerObj) != nil){
             countDownLabel.text = String(timerObj.getStartSeconds())
-    
         }
     }
+    func hideMenu(flag: Bool){
+        var menuView: UIView = self.viewWithTag(99)!
+        var cancelView: UIView = self.viewWithTag(98)!
+        
+        menuView.hidden = flag
+        cancelView.hidden = !flag
+    }
     func beginPressed(){
+        if(disableButtons){
+            disableButtons = false
+            return
+        }
         beginBlock?()
+        
     }
     func updateTime(seconds: Int){
         countDownLabel.text = String(seconds)

--- a/TempoWatch/SettingsView.swift
+++ b/TempoWatch/SettingsView.swift
@@ -13,6 +13,7 @@ public class SettingsView: UIView, UITextFieldDelegate{
     var width: CGFloat!
     var height: CGFloat!
     var mode: Int!
+    var disableButtons = false
     var timerObj: TimerModel!{
         didSet{
             updateLabels()
@@ -114,8 +115,8 @@ public class SettingsView: UIView, UITextFieldDelegate{
         circleView = BWCircularSlider(textColor:color, startColor:color, endColor:color, frame: frame)
         circleView.alpha = 0
         self.addSubview(circleView)
-        
-        var xImg =  UIImage(named:"xBtn")
+                
+        var xImg =  UIImage(named:"xbtn")
         var size = xImg?.size
         
         xBtn = UIButton(frame: CGRectMake(width - 30 - 5, 10, 25, 25))
@@ -145,6 +146,10 @@ public class SettingsView: UIView, UITextFieldDelegate{
         self.delegate.enableScroll(true)
     }
     func btnPressed(btn: UIButton){
+        if(disableButtons){
+            disableButtons = false
+            return
+        }
         var tag: Int = btn.tag
         var color: UIColor
         var maxValue: CGFloat


### PR DESCRIPTION
These should have been in independent commits or pull request but you know #yolo
@alphastory 

- Removed a ton of unnecessary logs
- Added in swipe delegates 
- Used swipe delgates to disable button presses 
      - Button presses and swipe delegates were competing for interaction 
      - Basically swipes were pressing buttons at the same time 
- Swapping the menu/cancel button on homeview 
- Allowing users to cancel the 3/2/1 timer 
- Resetting the pause menu if cancelled earler 
- Better state management between pause/cancel/start/swipe
- Put a preprocessor macro around the audio to avoid simulator crashes 
- renaming xBtn to xbtn -__-